### PR TITLE
add ruby syntax to Rails parameters in  readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 
 Rails parameters validations at the controller layer:
 
-```
+```ruby
 class FoosController < ApplicationController
   class Validations < StrongerParameters
     validates :name, :age, :color, presence: true, on: [:create, :update]


### PR DESCRIPTION
The markdown in for the Rails parameters section of the readme.md was missing ruby. The lack of syntax highlighting was getting to me.
